### PR TITLE
Use data model to display rows and columns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@
 node_modules
 /dist
 
+# Screenshots
+public/screenshots
+
 # local env files
 .env.local
 .env.*.local

--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,8 @@
+# TODO / next steps
+- [ ] Connect form to selectedDimensions state
+- [ ] Display "loading" in stage while loading
+- [ ] Display helpful error message in stage when the metadata file failed to load, parse, or create the ScreenshotMetadata instance
+- [ ] Display image plaques instead of file names
+- [ ] Repair headers: Generate row headers and column headers from dimensions and selected dimensions, render them in the row and XAxisRow components.
+- [ ] Typed properties in components
+- [ ] More validation (dimensions) when creating ScreenshotMetadata

--- a/src/components/Row.vue
+++ b/src/components/Row.vue
@@ -1,18 +1,17 @@
 <template>
     <tr class="row">
+        <!-- TODO array of headers label will be passed as prop in from parent & rendered, replacing TitleRow -->
         <td class="row--label">
             <div class="row--label-content">
                 <span class="row--label-text">1024</span>
             </div>
         </td>
-        <td class="row--screenshot">
+
+        <td class="row--screenshot" v-for="testcase in testcases" v-bind:key="testcase.screenshotFilename">
             <div class="row--screenshot-content">
-                <img src="https://www.placecage.com/g/1280/960" alt="I am an image">
-            </div>
-        </td>
-        <td class="row--screenshot">
-            <div class="row--screenshot-content">
-                <img src="https://www.placecage.com/g/1280/960" alt="I am an image">
+                <div>{{testcase.screenshotFilename}}</div>
+                <img v-if="testcase.isValid" :src="`screenshots/${testcase.screenshotFilename}`" :alt="testcase.screenshotFilename">
+                <span v-else>{{testcase.invalidReason}}</span>
             </div>
         </td>
     </tr>
@@ -20,7 +19,8 @@
 
 <script>
 	export default {
-		name: "Row"
+		name: "Row",
+        props: ['testcases']
 	}
 </script>
 

--- a/src/components/Stage.vue
+++ b/src/components/Stage.vue
@@ -6,14 +6,7 @@
                     <XAxisRow></XAxisRow>
                 </thead>
                 <tbody>
-                    <title-row></title-row>
-                    <row></row>
-                    <row></row>
-                    <row></row>
-                    <title-row></title-row>
-                    <row></row>
-                    <row></row>
-                    <row></row>
+                    <row v-for="( testcases, index) in grid" :testcases="testcases" :grid="grid" :colNumber="index" :key="index"></row>
                 </tbody>
             </table>
         </div>
@@ -27,8 +20,8 @@
 
 	export default {
 		name: "Stage",
-		components: { XAxisRow, Row, TitleRow },
-		props : [ 'sidebarIsVisible' ]
+		components: { XAxisRow, Row },
+		props : [ 'sidebarIsVisible', 'grid' ]
 	}
 </script>
 

--- a/src/model/ScreenshotMetaData.ts
+++ b/src/model/ScreenshotMetaData.ts
@@ -4,7 +4,7 @@ import {ScreenshotMetaDataJsonInterface} from "@/model/ScreenshotMetaDataJsonInt
 type DimensionMap = Map<string, string[]>
 
 export class ScreenshotMetaData {
-    constructor( readonly createdOn: Date, readonly campaign:string, readonly dimensions: DimensionMap, readonly testcases: TestCase[]) {
+    constructor( readonly createdOn: Date, readonly campaign: string, readonly dimensions: DimensionMap, readonly testCases: TestCase[]) {
     }
 
     public static fromObject( obj: ScreenshotMetaDataJsonInterface ): ScreenshotMetaData {
@@ -20,5 +20,9 @@ export class ScreenshotMetaData {
         const subset = new Map<string,string[]>();
         dimensionNames.forEach( name => subset.set( name, this.dimensions.get( name ) || [] ) );
         return subset;
+    }
+
+    getRemainingDimensions( dimensionNames: string[] ): string[] {
+        return [...this.dimensions.keys()].filter( dimensionName => dimensionNames.indexOf( dimensionName ) === -1 );
     }
 }

--- a/tests/unit/ScreenshotMetaData.spec.ts
+++ b/tests/unit/ScreenshotMetaData.spec.ts
@@ -1,6 +1,6 @@
 import {ScreenshotMetaData} from "@/model/ScreenshotMetaData";
 import {ScreenshotMetaDataJsonInterface} from "@/model/ScreenshotMetaDataJsonInterface";
-import {BANNER, BROWSER} from "@/model/Dimensions";
+import {BANNER, BROWSER, OPERATING_SYSTEM, RESOLUTION} from "@/model/Dimensions";
 
 describe('ScreenshotMetaData', () => {
 
@@ -74,7 +74,7 @@ describe('ScreenshotMetaData', () => {
             expect( metaData.createdOn ).toStrictEqual( new Date(1234) );
             expect( metaData.campaign ).toBe( '00-ba-200416');
             expect( metaData.dimensions.size ).toBe( 4 );
-            expect( metaData.testcases.length ).toBe( 1 );
+            expect( metaData.testCases.length ).toBe( 1 );
         });
 
         xit('validates dimensions', () => {
@@ -95,5 +95,13 @@ describe('ScreenshotMetaData', () => {
             "safari",
             "chrome"
         ] )
+    })
+
+    it('can get the remaining dimensions', () => {
+        const metaData = ScreenshotMetaData.fromObject( rawData );
+
+        const remaining = metaData.getRemainingDimensions( [ BANNER, BROWSER ] );
+
+        expect( remaining ).toStrictEqual( [ OPERATING_SYSTEM, RESOLUTION] );
     })
 });

--- a/tests/unit/createGrid.spec.ts
+++ b/tests/unit/createGrid.spec.ts
@@ -7,7 +7,7 @@ describe('createGrid', () => {
 
     const buf = fs.readFileSync( __dirname + '/example_metadata.json' );
     const metaData = ScreenshotMetaData.fromObject( JSON.parse( buf.toString() ) );
-    const testCases = metaData.testcases;
+    const testCases = metaData.testCases;
 
     it( 'can create a grid from banner dimension', () => {
         const rowDimensions = metaData.getDimensionSubset([RESOLUTION]) ;


### PR DESCRIPTION
This commit adds loading of of the metadata as a data model to the app.
It's very rough (breaking headers), but demonstrates how to display the grid.

Before first use, copy the contents of a banner-directory into
`public/screenshots`.