### PR TITLE
Add row headers

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -3,7 +3,7 @@
         <Header></Header>
         <SidebarToggle v-bind:sidebar-is-visible="sidebarIsVisible" v-on:toggle-sidebar="onToggleSidebar"></SidebarToggle>
         <sidebar v-bind:sidebar-is-visible="sidebarIsVisible"></sidebar>
-        <stage v-bind:sidebar-is-visible="sidebarIsVisible" v-bind:grid="grid"></stage>
+        <stage v-bind:sidebar-is-visible="sidebarIsVisible" v-bind:grid="grid" v-bind:rowHeaders="rowHeaders"></stage>
     </div>
 </template>
 
@@ -13,7 +13,12 @@
 	import Stage from "@/components/Stage.vue";
     import {computed, defineComponent, reactive, ref, toRefs, watchEffect} from '@vue/composition-api';
     import {ScreenshotMetaData} from "@/model/ScreenshotMetaData";
-    import { BROWSER } from "@/model/Dimensions";
+    import {BROWSER, RESOLUTION} from "@/model/Dimensions";
+    import MetaData from './../../banner-screenshots/banner-shots/00-ba-200416/metadata.json';
+	import SidebarToggle from "@/components/SidebarToggle.vue";
+    import {createGrid} from "@/model/createGrid";
+    import {createRowHeaders} from "@/model/createRowHeaders";
+    import {RowHeader} from "@/model/RowHeader";
 
     interface MetadataState {
         isLoading: boolean;
@@ -21,11 +26,7 @@
         selectedDimensions: string[];
     }
 
-    import MetaData from './../../banner-screenshots/banner-shots/00-ba-200416/metadata.json';
-	import SidebarToggle from "@/components/SidebarToggle.vue";
-    import {createGrid} from "@/model/createGrid";
-
-	export default defineComponent( {
+    export default defineComponent( {
 		name: 'App',
 		components: {
 			SidebarToggle,
@@ -44,7 +45,7 @@
             const metaDataInit: MetadataState = {
                 isLoading: true,
                 metaData: null,
-                selectedDimensions: [ BROWSER ]
+                selectedDimensions: [ BROWSER, RESOLUTION ]
 
             };
             const metaDataState = reactive( metaDataInit );
@@ -70,12 +71,21 @@
 
                 return createGrid( metaDataState.metaData.testCases, selectedRows, orderRows);
             });
-            // TODO create computed property of row header labels, based on metaDataState.selectedDimensions and length of dimensions values
+            const rowHeaders = computed<RowHeader[][]>((): RowHeader[][] => {
+                if( metaDataState.metaData === null) {
+                    return [];
+                }
+                return createRowHeaders(metaDataState.metaData.getDimensionSubset( metaDataState.selectedDimensions ) );
+            } );
+
+            // TODO create computed property of column header labels, based on metaDataState.selectedDimensions
+
             return {
 				metaData,
                 sidebarIsVisible,
                 onToggleSidebar,
                 grid,
+                rowHeaders,
                 ...toRefs( metaDataState )
             }
         },

--- a/src/components/Row.ts
+++ b/src/components/Row.ts
@@ -1,0 +1,36 @@
+import TitleRow from "@/components/TitleRow.vue";
+import ValueRow from "@/components/ValueRow.vue";
+import Vue, {VNode} from "vue";
+
+const Row = Vue.extend({
+    functional: true,
+    props: {
+        headers: Array,
+        testcases: Array
+    },
+    render: function (createElement, context): VNode[] {
+        const headerLength = context.props.headers.length;
+        const elements = [];
+        // Add additional title rows when the headers have more than 1 element, indicating the start of a new "subsection"
+        for (let i = 0; i < headerLength - 1; i++) {
+            elements.push(createElement(TitleRow, {
+                    props: {
+                        header: context.props.headers[i],
+                        columns: context.props.testcases.length
+                    }
+                })
+            )
+        }
+        elements.push(createElement(ValueRow, {
+                props: {
+                    testcases: context.props.testcases,
+                    header: context.props.headers[headerLength - 1]
+                }
+            })
+        );
+        return elements;
+    }
+
+});
+
+export default Row;

--- a/src/components/Stage.vue
+++ b/src/components/Stage.vue
@@ -6,7 +6,11 @@
                     <XAxisRow></XAxisRow>
                 </thead>
                 <tbody>
-                    <row v-for="( testcases, index) in grid" :testcases="testcases" :grid="grid" :colNumber="index" :key="index"></row>
+                    <row v-for="( testcases, index) in grid"
+                         :testcases="testcases"
+                         :key="index"
+                         :headers="rowHeaders[index]"
+                    />
                 </tbody>
             </table>
         </div>
@@ -14,14 +18,17 @@
 </template>
 
 <script>
-	import TitleRow from "@/components/TitleRow";
-	import Row from "@/components/Row";
+	import Row from "@/components/Row.ts";
 	import XAxisRow from "@/components/XAxisRow";
 
 	export default {
 		name: "Stage",
 		components: { XAxisRow, Row },
-		props : [ 'sidebarIsVisible', 'grid' ]
+		props : {
+			sidebarIsVisible: Boolean,
+			grid: Array,
+            rowHeaders: Array
+		}
 	}
 </script>
 

--- a/src/components/TitleRow.vue
+++ b/src/components/TitleRow.vue
@@ -2,12 +2,12 @@
     <tr class="title-row">
         <td class="title-row--label">
             <div class="title-row--icon">
-                <Icon icon="ie11"></Icon>
+                <Icon :icon="header.label"></Icon>
             </div>
         </td>
-        <td colspan="3">
+        <td :colspan="columns">
             <div class="title-row--column-label">
-                Internet Explorer
+                {{ header.label}}
             </div>
         </td>
     </tr>
@@ -15,9 +15,14 @@
 
 <script>
 	import Icon from "@/components/Icon";
+	import {RowHeader} from "@/model/RowHeader";
 	export default {
 		name: "TitleRow",
-		components: { Icon }
+		components: { Icon },
+        props: {
+			header: RowHeader,
+            columns: Number
+        }
 	}
 </script>
 

--- a/src/components/ValueRow.vue
+++ b/src/components/ValueRow.vue
@@ -1,9 +1,9 @@
 <template>
     <tr class="row">
-        <!-- TODO array of headers label will be passed as prop in from parent & rendered, replacing TitleRow -->
+
         <td class="row--label">
             <div class="row--label-content">
-                <span class="row--label-text">1024</span>
+                <span class="row--label-text">{{ header.label }}</span>
             </div>
         </td>
 
@@ -18,9 +18,14 @@
 </template>
 
 <script>
+	import {RowHeader} from "@/model/RowHeader";
+
 	export default {
-		name: "Row",
-        props: ['testcases']
+		name: "ValueRow",
+        props: {
+			testcases: Array,
+			header: RowHeader
+		}
 	}
 </script>
 

--- a/src/model/Dimensions.ts
+++ b/src/model/Dimensions.ts
@@ -6,3 +6,5 @@ export const OPERATING_SYSTEM = 'operating_system';
 export const ORIENTATION = 'orientation';
 export const RESOLUTION = 'resolution';
 export const ALLOWED_DIMENSIONS = [BANNER, BROWSER, DEVICE, OPERATING_SYSTEM, ORIENTATION, RESOLUTION];
+
+export type DimensionMap = Map<string,string[]>

--- a/src/model/RowHeader.ts
+++ b/src/model/RowHeader.ts
@@ -1,0 +1,4 @@
+export class RowHeader {
+    constructor(readonly dimensionLabel: string, readonly label: string, readonly span: number) {
+    }
+}

--- a/src/model/ScreenshotMetaData.ts
+++ b/src/model/ScreenshotMetaData.ts
@@ -1,7 +1,6 @@
 import {TestCase} from "@/model/TestCase";
 import {ScreenshotMetaDataJsonInterface} from "@/model/ScreenshotMetaDataJsonInterface";
-
-type DimensionMap = Map<string, string[]>
+import {DimensionMap} from "@/model/Dimensions";
 
 export class ScreenshotMetaData {
     constructor( readonly createdOn: Date, readonly campaign: string, readonly dimensions: DimensionMap, readonly testCases: TestCase[]) {

--- a/src/model/ScreenshotMetaDataJsonInterface.ts
+++ b/src/model/ScreenshotMetaDataJsonInterface.ts
@@ -8,8 +8,8 @@ type FixedLengthArray<T extends any[]> =
     & { [Symbol.iterator]: () => IterableIterator< ArrayItems<T> > }
 
 export interface ScreenshotMetaDataJsonInterface {
-    createdOn: number,
-    campaign: string,
-    dimensions: Array<FixedLengthArray<[string, string[]]>>,
-    testCases: TestCaseJsonInterface[]
+    createdOn: number;
+    campaign: string;
+    dimensions: Array<FixedLengthArray<[string, string[]]>>;
+    testCases: TestCaseJsonInterface[];
 }

--- a/src/model/createRowHeaders.ts
+++ b/src/model/createRowHeaders.ts
@@ -1,0 +1,39 @@
+import {DimensionMap} from "@/model/Dimensions";
+import {RowHeader} from "@/model/RowHeader";
+
+function multiplyLengths( arr: Array<string[]> ) {
+    return arr.reduce( (multipliedLength, values ) => multipliedLength * values.length, 1 );
+}
+
+export function createRowHeaders( dimensions: DimensionMap): RowHeader[][] {
+    const dimensionValueArray = [...dimensions.values()];
+
+    // Number of rows is the length of all dimension value array multiplied
+    const rowCount = multiplyLengths(dimensionValueArray);
+
+    // Each "level" of headers spans a number of rows equal to the product of the lengths of all following dimension arrays
+    const spanSizes = [];
+    for( let i=0; i< dimensionValueArray.length; i++ ) {
+        spanSizes.push( multiplyLengths( dimensionValueArray.slice( i+1 ) ));
+    }
+
+    const headers: RowHeader[][] = Array(rowCount);
+    let depth = 0;
+    for( const [dimensionName, dimensionValues] of dimensions.entries() ) {
+        const step = spanSizes[depth];
+        // Distribute the dimension values in steps according to their span size
+        for( let rowIndex=0; rowIndex < rowCount; rowIndex += step ) {
+            if(!headers[rowIndex]) {
+                headers[rowIndex] = [];
+            }
+            // "iteration" normalize the jumping row index back to a 0,1,2,3... progression of values
+            const iteration = rowIndex / step;
+            // The indices for dimension values have to oscillate between 0 and dimensionValues.length-1, hence the modulo
+            const valueIndex = iteration % dimensionValues.length;
+            headers[rowIndex].push( new RowHeader( dimensionName, dimensionValues[valueIndex], spanSizes[depth] ) );
+        }
+        depth++;
+    }
+
+    return headers;
+}

--- a/tests/unit/createRowHeaders.spec.ts
+++ b/tests/unit/createRowHeaders.spec.ts
@@ -1,0 +1,58 @@
+import {BANNER, BROWSER, DimensionMap, OPERATING_SYSTEM} from "@/model/Dimensions";
+import {createRowHeaders} from "@/model/createRowHeaders";
+import {RowHeader} from "@/model/RowHeader";
+
+describe( 'createRowHeaders', () => {
+    it('creates simple headers', () => {
+        const dimensions: DimensionMap = new Map<string, string[]>([
+            [BANNER, ['ctrl', 'var']]
+        ]);
+        const rowHeaders = createRowHeaders( dimensions );
+
+        expect( rowHeaders ).toStrictEqual([
+            [ new RowHeader( BANNER, 'ctrl', 1) ],
+            [ new RowHeader( BANNER, 'var', 1) ],
+        ])
+    } );
+
+    it('creates nested headers', () => {
+        const dimensions: DimensionMap = new Map<string, string[]>([
+            [BANNER, ['ctrl', 'var']],
+            [BROWSER, ['chrome', 'edge', 'firefox']]
+        ]);
+        const rowHeaders = createRowHeaders( dimensions );
+
+        expect( rowHeaders ).toStrictEqual([
+            [ new RowHeader( BANNER, 'ctrl', 3), new RowHeader( BROWSER, 'chrome', 1) ],
+            [ new RowHeader( BROWSER, 'edge', 1) ],
+            [ new RowHeader( BROWSER, 'firefox', 1) ],
+            [ new RowHeader( BANNER, 'var', 3), new RowHeader( BROWSER, 'chrome', 1)  ],
+            [ new RowHeader( BROWSER, 'edge', 1) ],
+            [ new RowHeader( BROWSER, 'firefox', 1) ],
+        ])
+    })
+
+    it('creates deeply nested headers', () => {
+        const dimensions: DimensionMap = new Map<string, string[]>([
+            [BANNER, ['ctrl', 'var']],
+            [BROWSER, ['chrome', 'edge', 'firefox']],
+            [OPERATING_SYSTEM, ['win10', 'macos']],
+        ]);
+        const rowHeaders = createRowHeaders( dimensions );
+
+        expect( rowHeaders ).toStrictEqual([
+            [ new RowHeader( BANNER, 'ctrl', 6), new RowHeader( BROWSER, 'chrome', 2), new RowHeader( OPERATING_SYSTEM, 'win10', 1) ],
+            [ new RowHeader( OPERATING_SYSTEM, 'macos', 1) ],
+            [ new RowHeader( BROWSER, 'edge', 2), new RowHeader( OPERATING_SYSTEM, 'win10', 1) ],
+            [ new RowHeader( OPERATING_SYSTEM, 'macos', 1) ],
+            [ new RowHeader( BROWSER, 'firefox', 2), new RowHeader( OPERATING_SYSTEM, 'win10', 1) ],
+            [ new RowHeader( OPERATING_SYSTEM, 'macos', 1) ],
+            [ new RowHeader( BANNER, 'var', 6), new RowHeader( BROWSER, 'chrome', 2), new RowHeader( OPERATING_SYSTEM, 'win10', 1) ],
+            [ new RowHeader( OPERATING_SYSTEM, 'macos', 1) ],
+            [ new RowHeader( BROWSER, 'edge', 2), new RowHeader( OPERATING_SYSTEM, 'win10', 1) ],
+            [ new RowHeader( OPERATING_SYSTEM, 'macos', 1) ],
+            [ new RowHeader( BROWSER, 'firefox', 2), new RowHeader( OPERATING_SYSTEM, 'win10', 1) ],
+            [ new RowHeader( OPERATING_SYSTEM, 'macos', 1) ],
+        ])
+    })
+})


### PR DESCRIPTION
Generate row multidimensional row headers from dimensions with the new
`createRowHeaders` function - check out its test to see the header row
data structure for different dimensions.
Change initial row dimensions to 2.
Use TitleRow when there is more than 1 header for a row.
Rename "Row" to "ValueRow" to make row for the functional "Row"
component that renders a variable number of title rows and one value
row, depending on the number of headers.

I've experimented with row-spanning headers, dropping the title rows,
but that did not work with the current layout. It would be an option for
the future.