### PR TITLE
Move remaining header infomation to image plaque

### DIFF
--- a/src/components/Row.ts
+++ b/src/components/Row.ts
@@ -2,17 +2,20 @@ import TitleRow from "@/components/TitleRow.vue";
 import ValueRow from "@/components/ValueRow.vue";
 import Vue, {VNode} from "vue";
 
+export const MAX_HEADERS = 1;
+
 const Row = Vue.extend({
     functional: true,
     props: {
         headers: Array,
-        testcases: Array
+        testcases: Array,
+        contextInfo: Array,
     },
     render: function (createElement, context): VNode[] {
         const headerLength = context.props.headers.length;
         const elements = [];
         // Add additional title rows when the headers have more than 1 element, indicating the start of a new "subsection"
-        for (let i = 0; i < headerLength - 1; i++) {
+        for (let i = 0; i < Math.min(headerLength - 1, MAX_HEADERS ); i++) {
             elements.push(createElement(TitleRow, {
                     props: {
                         header: context.props.headers[i]
@@ -23,7 +26,8 @@ const Row = Vue.extend({
         elements.push(createElement(ValueRow, {
                 props: {
                     testcases: context.props.testcases,
-                    header: context.props.headers[headerLength - 1]
+                    header: context.props.headers[headerLength - 1],
+                    'context-info': context.props.contextInfo,
                 }
             })
         );

--- a/src/components/Stage.vue
+++ b/src/components/Stage.vue
@@ -6,6 +6,7 @@
                  :testcases="testcases"
                  :key="index"
                  :headers="rowHeaders[index]"
+                 :context-info="contextInfo"
             />
         </div>
     </div>
@@ -22,7 +23,8 @@
 			sidebarIsVisible: Boolean,
 			grid: Array,
             rowHeaders: Array,
-            columnHeaders: Array
+            columnHeaders: Array,
+            contextInfo: Array,
 		}
 	}
 </script>

--- a/src/components/ValueRow.vue
+++ b/src/components/ValueRow.vue
@@ -14,7 +14,7 @@
             <div class="row--screenshot-content">
                 <div v-if="testcase.isValid">
                     <img :src="`screenshots/${testcase.screenshotFilename}`" :alt="testcase.screenshotFilename">
-                    <div class="row--screenshot-metadata">Resolution: 1024x768</div>
+                    <div v-for="dimensionName in contextInfo" :key="dimensionName" class="row--screenshot-metadata">{{dimensionName}}: {{testcase.dimensions.get( dimensionName )}}</div>
                 </div>
                 <div v-else class="row--screenshot-invalid-reason">
                     <div class="row--screenshot-invalid-reason-text">{{testcase.invalidReason}}</div>
@@ -32,7 +32,11 @@
 		name: "ValueRow",
         props: {
 			testcases: Array,
-			header: RowHeader
+			header: RowHeader,
+            contextInfo: {
+				type: Array,
+                default: () => []
+            }
 		}
 	}
 </script>


### PR DESCRIPTION
If we have more than 2 headers in the Y row, display the last headers
underneath each image.