### PR TITLE
Ignore screenshots when building

### DIFF
--- a/vue.config.js
+++ b/vue.config.js
@@ -1,0 +1,10 @@
+module.exports = {
+	chainWebpack: config => {
+		// Avoid copying local screenshots when building,
+		// see https://github.com/vuejs/vue-cli/issues/2231
+		config.plugin('copy').tap(options => {
+			options[0][0].ignore.push('screenshots/**/*');
+			return options;
+		});
+	}
+}


### PR DESCRIPTION
Added webpack configuration to prevent `npm run build` from copying the `public/screenshots` directory to the `dist` directory.